### PR TITLE
fix: extend script to capture props that come in as a tstype

### DIFF
--- a/src/generate-config-file.ts
+++ b/src/generate-config-file.ts
@@ -243,39 +243,22 @@ function addCompProps(
 }
 
 /**
- * Parses the raw components data obtained from a `generateConfigFile` into a
- * comprehensible CompPropTypes object.
+ * Given a CompPropTypes object, groups common prop types into a general category.
  *
- * @param rawData - Raw components data.
- * @returns Parsed CompPropTypes object.
+ * @param compPropTypes - Previously processed component prop types,
+ * ordered by component name and prop type key.
+ * @returns CompPropTypes object containing general category.
  */
-function parseCompData(rawData: Record<string, CompData[]>): CompPropTypes {
-  const compPropTypes: CompPropTypes = {}
-  Object.values(rawData).forEach((file: CompData[]) => {
-    file.forEach((comp) => {
-      compPropTypes[comp.displayName] = addCompProps(comp, compPropTypes[comp.displayName] ?? {})
-    })
-  })
-  // sort by component names
-  const orderedCompPropTypesKeys = Object.keys(compPropTypes).sort((a, b) => a.localeCompare(b))
-
-  const orderedCompPropTypes = orderedCompPropTypesKeys.reduce<CompPropTypes>((obj, key) => {
-    const data = compPropTypes[key]
-    if (data) {
-      obj[key] = data
-    }
-    return obj
-  }, {})
-
+function groupGeneralProps(compPropTypes: CompPropTypes) {
   const general: Record<string, string[]> = {}
   // add General category
   const allCompPropTypes: CompPropTypes = {
     General: general,
-    ...orderedCompPropTypes
+    ...compPropTypes
   }
 
   // Compute General Props
-  Object.entries(allCompPropTypes).forEach(([key, value]) => {
+  Object.entries(compPropTypes).forEach(([key, value]) => {
     Object.keys(value).forEach((prop) => {
       const hasDuplicate: boolean =
         general[prop] !== undefined ||
@@ -302,6 +285,34 @@ function parseCompData(rawData: Record<string, CompData[]>): CompPropTypes {
   })
 
   return allCompPropTypes
+}
+
+/**
+ * Parses the raw components data obtained from a `generateConfigFile` into a
+ * comprehensible CompPropTypes object.
+ *
+ * @param rawData - Raw components data.
+ * @returns Parsed CompPropTypes object.
+ */
+function parseCompData(rawData: Record<string, CompData[]>): CompPropTypes {
+  const compPropTypes: CompPropTypes = {}
+  Object.values(rawData).forEach((file: CompData[]) => {
+    file.forEach((comp) => {
+      compPropTypes[comp.displayName] = addCompProps(comp, compPropTypes[comp.displayName] ?? {})
+    })
+  })
+  // sort by component names
+  const orderedCompPropTypesKeys = Object.keys(compPropTypes).sort((a, b) => a.localeCompare(b))
+
+  const orderedCompPropTypes = orderedCompPropTypesKeys.reduce<CompPropTypes>((obj, key) => {
+    const data = compPropTypes[key]
+    if (data) {
+      obj[key] = data
+    }
+    return obj
+  }, {})
+
+  return groupGeneralProps(orderedCompPropTypes)
 }
 
 /**

--- a/src/generate-config-file.ts
+++ b/src/generate-config-file.ts
@@ -171,7 +171,7 @@ async function generateComponentData(files: string[], ignore: string[] = []): Pr
 function getPropValues(propData: PropData): string[] {
   const values: string[] = []
   if (propData.type?.name === 'enum' && Array.isArray(propData.type.value)) {
-    propData.type.value.forEach((val) => {
+    propData.type.value.forEach((val: { value: string }) => {
       // fix for "'top'" double quotation issue
 
       values.push(
@@ -193,6 +193,18 @@ function getPropValues(propData: PropData): string[] {
           )
         })
       })
+  } else if (propData.tsType?.name === 'union' && Array.isArray(propData.tsType.elements)) {
+    propData.tsType.elements.forEach((el) => {
+      // fix for "'top'" double quotation issue
+
+      if (el.name === 'literal') {
+        values.push(
+          el.value.startsWith("'") && el.value.endsWith("'")
+            ? el.value.substring(1, el.value.length - 1)
+            : el.value
+        )
+      }
+    })
   }
   return values
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,18 +14,38 @@ export interface CommandLineOptions {
   ignore?: string[]
 }
 
+export interface EnumValue {
+  value: string
+}
+
 export interface EnumType {
   name: 'enum'
-  value: Array<{ value: string }>
+  value: EnumValue[]
 }
 
 export interface UnionType {
   name: 'union'
-  value: Array<PropData['type']>
+  value: Array<EnumType | UnionType>
+}
+
+export interface TSElement {
+  name: string
+  value: string
+}
+
+export interface TSUnionType {
+  name: string
+  elements?: TSElement[]
+}
+
+export interface PropType {
+  name: string
+  value: unknown
 }
 
 export interface PropData {
-  type: EnumType | UnionType
+  type?: PropType
+  tsType?: TSUnionType
 }
 
 export interface CompData {


### PR DESCRIPTION
#### Changelog

**New**

- EnumValue, TSElement, TSUnionType and PropType interfaces
- Extra conditional in `getPropValues` to account for prop types that come in as "tsType" instead of "type"


#### Testing / reviewing

N/A