### PR TITLE
fix: refine value generating logic

### DIFF
--- a/src/generate-config-file.ts
+++ b/src/generate-config-file.ts
@@ -191,7 +191,7 @@ function getPropValues(propData: PropData): string[] {
   if (propData.type?.name === 'enum' && Array.isArray(propData.type.value)) {
     propData.type.value.forEach((val: EnumValue) => {
       const sanitizedVal = retrieveStringValue(val)
-      if (sanitizedVal !== undefined) {
+      if (sanitizedVal !== undefined && sanitizedVal !== '') {
         values.push(sanitizedVal)
       }
     })
@@ -201,7 +201,7 @@ function getPropValues(propData: PropData): string[] {
       .forEach((nested) => {
         nested.value?.forEach((val: EnumValue) => {
           const sanitizedVal = retrieveStringValue(val)
-          if (sanitizedVal !== undefined) {
+          if (sanitizedVal !== undefined && sanitizedVal !== '') {
             values.push(sanitizedVal)
           }
         })
@@ -212,7 +212,7 @@ function getPropValues(propData: PropData): string[] {
 
       if (el.name === 'literal') {
         const sanitizedVal = retrieveStringValue({ value: el.value, computed: false })
-        if (sanitizedVal !== undefined) {
+        if (sanitizedVal !== undefined && sanitizedVal !== '') {
           values.push(sanitizedVal)
         }
       }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -16,6 +16,7 @@ export interface CommandLineOptions {
 
 export interface EnumValue {
   value: string
+  computed: boolean
 }
 
 export interface EnumType {


### PR DESCRIPTION
Closes #28 

Refines config generator logic for retrieving attribute values to:
- Remove double quotes ("") from beginning and end of strings
- Ignore empty/undefined strings
- Do not capture objects/stringified objects

#### Changelog

**New**

- use new `retrieveStringValue` function to treat attribute values before storing and discard `computed` vales


#### Testing / reviewing

- Clone this repository:
     - `npm install`
     - `npm run build`
- From local test repo (can use https://github.com/carbon-design-system/carbon-addons-iot-react):
     - `npx -y @ibm/telemetry-js-config-generator --endpoint=1234 --id=hi123 --files ./src/**/*.(tsx|js|jsx) --fi
le-path=deployed-telemetry.yml` from within instrumented (packages/react) dir 
     - `node /Users/[User]/Desktop/Projects/telemetry-js-config-generator/dist/generate-config-file.js --endpoint=1234 --id=hi123 --files ./src/**/*.(tsx|js|jsx) --file-path=pr-telemetry.yml` from within instrumented (packages/react) dir (must be the path to your local clone of telemetry config generator)
     - Compare the two generated files (might want to use `Partial Diff` vs code extension). Ensure new `pr-telemetry.yml` doesn't have any of the issues that the `deployed-telemetry.yml` presents and no regressions