### PR TITLE
feat!: add scope specific commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Use this tool to automatically generate an
 with your project-specific configurations.
 
 > **Note**  
-> For v1, please see [v1 docs](https://github.com/ibm-telemetry/telemetry-js-config-generator/tree/v1.0.3?tab=readme-ov-file#ibm-telemetry-js-config-generator)
+> For v1, please see
+> [v1 docs](https://github.com/ibm-telemetry/telemetry-js-config-generator/tree/v1.0.3?tab=readme-ov-file#ibm-telemetry-js-config-generator)
 
 ## Generating Config File
 
@@ -27,7 +28,8 @@ your CI environment, for example), you can call the bin like so:
 `ibmtelemetry-config generate --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)`
 
 A `telemetry.yml` file will be generated inside the cwd path, unless a file path is specified (see
-parameters). Verify that the generated output is correct before using the config file.
+[parameters](#parameters)). Verify that the generated output is correct before using the config
+file.
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,24 @@ with your project-specific configurations.
 > For v1, please see
 > [v1 docs](https://github.com/ibm-telemetry/telemetry-js-config-generator/tree/v1.0.3?tab=readme-ov-file#ibm-telemetry-js-config-generator)
 
-## Generating Config File
+## Commands
+
+```
+Usage: ibmtelemetry-config [options] [command]
+
+Options:
+  -h, --help          display help for command
+
+Commands:
+  generate [options]  Generate IBM telemetry config file.
+  update [options]    Modify in whole or part an existing telemetry config file
+  npm                 Add, update or remove npm scope
+  js                  Add, update or remove js scope
+  jsx                 Sdd, update or remove jsx scope
+  help [command]      display help for command
+```
+
+### Generate
 
 From the root of the project that needs to be instrumented with IBM Telemetry, run the `generate`
 command:
@@ -31,65 +48,115 @@ A `telemetry.yml` file will be generated inside the cwd path, unless a file path
 [parameters](#parameters)). Verify that the generated output is correct before using the config
 file.
 
-### Parameters
+```
+Usage: ibmtelemetry-config generate [options]
 
-| Param     | Usage               | Description                                                                                                                                                                                             | Required                                                                                                           | Type             | Default           |
-| --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------- | ----------------- |
-| id        | `--id`              | Unique identifier assigned on a per-project basis. See [Onboarding a package to IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js?tab=readme-ov-file#onboarding-a-package-to-ibm-telemetry). | Required                                                                                                           | String           | -                 |
-| endpoint  | `--endpoint`        | URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to.                                                                                            | Required                                                                                                           | String           | -                 |
-| files     | `-f`, `--files`     | Files to scan component props for (used to generate `allowedAttributeNames` and `allowedAttributeStringValues` arrays in JSX scope config). Can be a space-separated list of files or a glob.           | Required when including JSX scope in telemetry config file (done by default unless opt-out, see `--no-jsx` param). | String[], String | -                 |
-| file path | `-p`, `--file-path` | Path to create config file at.                                                                                                                                                                          | Optional                                                                                                           | String           | `./telemetry.yml` |
-| ignore    | `-i`, `--ignore`    | Files to ignore when scanning for JSX Scope attributes, in glob(s) form.                                                                                                                                | Optional                                                                                                           | String[], String | -                 |
-| no npm    | `--no-npm`          | Use this option to exclude `npm` scope config from generated telemetry config file.                                                                                                                     | Optional                                                                                                           | param only       | -                 |
-| no jsx    | `--no-jsx`          | Use this option to exclude `JSX` scope config from generated telemetry config file. Omit supplying the `-f, --files` and `-i, --ignore` arguments when opting out of JSX config.                        | Optional                                                                                                           | param only       | -                 |
-| no js     | `--no-js`           | Use this option to exclude `js` scope config from generated telemetry config file.                                                                                                                      | Optional                                                                                                           | param only       | -                 |
+Generate IBM telemetry config file.
 
-### Example Usage
+Options:
+  --id <project-id>            Project Id, should be obtained from the IBM Telemetry team
+  --endpoint <endpoint>        URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to.
+  -f, --files <files...>       List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options
+  -i, --ignore <files...>      Files to ignore when scanning for JSX Scope attributes, in glob(s) form.
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  --no-npm                     Disables config generation for npm scope
+  --no-jsx                     Disables config generation for JSX scope
+  --no-js                      Disables config generation for JS scope
+  -h, --help                   display help for command
+```
+
+#### Example Usage
 
 `npx -y @ibm/telemetry-js-config-generator generate --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx) --file-path ./packages/sample/telemetry.yml -i **/DataTable/**/*.tsx **/Copy/** --no-npm --no-js`
 
 `ibmtelemetry-config generate --id sample-id --endpoint https://example.com/v1/metrics --no-jsx`
 
-## Updating existing config file
+### Update
 
 To update an existing telemetry config file, run the `update` command. You can use this command to
 regenerate entirely a telemetry configuration or only in-part (see available parameters). Remember
 to supply the `file path` parameter if your telemetry config is not at the default location.
 
-### Parameters
+```
+Usage: ibmtelemetry-config update [options]
 
-| Param     | Usage               | Description                                                                                                                                                                                                                                                                                                     | Required                                                                                        | Type             | Default           |
-| --------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------- | ----------------- |
-| id        | `--id`              | Unique identifier assigned on a per-project basis. See [Onboarding a package to IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js?tab=readme-ov-file#onboarding-a-package-to-ibm-telemetry). Supplying this optional parameter will overwrite the current `id` set in the existing telemetry config. | Optional                                                                                        | String           | -                 |
-| endpoint  | `--endpoint`        | URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to. Supplying this optional parameter will overwrite the current `endpoint` set in the existing telemetry config.                                                                                      | Optional                                                                                        | String           | -                 |
-| files     | `-f`, `--files`     | Files to scan component props for (used to generate `allowedAttributeNames` and `allowedAttributeStringValues` arrays in JSX scope config). Can be a space-separated list of files or a glob.                                                                                                                   | Optional. If this parameter is not specified, the `jsx` scope will **not** be regenerated.      | String[], String | -                 |
-| file path | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file.                                                                                                                                                                                                                          | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String           | `./telemetry.yml` |
-| ignore    | `-i`, `--ignore`    | Files to ignore when scanning for JSX Scope attributes, in glob(s) form.                                                                                                                                                                                                                                        | Optional                                                                                        | String[], String | -                 |
-| no npm    | `--no-npm`          | Use this option to bypass updating `npm` scope config. Note that an existing npm configuration will not be removed by using this option.                                                                                                                                                                        | Optional                                                                                        | param only       | -                 |
-| no jsx    | `--no-jsx`          | Use this option to bypass updating `jsx` scope config. Note that an existing jsx configuration will not be removed by using this option. Omit supplying the `-f, --files` and `-i, --ignore` arguments when opting out of JSX config.                                                                           | Optional                                                                                        | param only       | -                 |
-| no js     | `--no-js`           | Use this option to bypass updating `js` scope config. Note that an existing js configuration will not be removed by using this option.                                                                                                                                                                          | Optional                                                                                        | param only       | -                 |
+Modify in whole or part an existing telemetry config file
 
-### Example Usage
+Options:
+  --id <project-id>            Project Id, should be obtained from the IBM Telemetry team
+  --endpoint <endpoint>        URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to.
+  -f, --files <files...>       List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options
+  -i, --ignore <files...>      Files to ignore when scanning for JSX Scope attributes, in glob(s) form.
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  --no-npm                     Disables config generation for npm scope
+  --no-jsx                     Disables config generation for JSX scope
+  --no-js                      Disables config generation for JS scope
+  -h, --help                   display help for command
+```
+
+#### Example Usage
 
 `npx -y @ibm/telemetry-js-config-generator update --files ./src/components/**/*.(tsx|js|jsx)`
 
 `ibmtelemetry-config update --no-jsx`
-
-## Adding, removing and updating scopes
-
-You may add, update or remove scopes from an existing telemetry configuration file by using the
-scope specific commands:
 
 ### npm
 
 Use `npm` command along with `add`, `update` or `remove` subcommands. Remember to supply the
 `file path` parameter if your telemetry config is not at the default location.
 
-#### Parameters
+```
+Usage: ibmtelemetry-config npm [options] [command]
 
-| Param     | Command                                                   | Usage               | Description                                                                            | Required                                                                                        | Type   | Default           |
-| --------- | --------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------ | ----------------- |
-| file path | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file. | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String | `./telemetry.yml` |
+Add, update or remove npm scope
+
+Options:
+  -h, --help        display help for command
+
+Commands:
+  add [options]     Add npm scope to current config file
+  update [options]  Regenerate the npm scope
+  remove [options]  Remove npm scope from current config file
+  help [command]    display help for command
+```
+
+#### Subcommands
+
+##### Add
+
+```
+Usage: ibmtelemetry-config npm add [options]
+
+Add npm scope to current config file
+
+Options:
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
+
+##### Update
+
+```
+Usage: ibmtelemetry-config npm update [options]
+
+Regenerate the npm scope
+
+Options:
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
+
+##### Remove
+
+```
+Usage: ibmtelemetry-config npm remove [options]
+
+Remove npm scope from current config file
+
+Options:
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
 
 #### Example Usage
 
@@ -104,13 +171,62 @@ Use `npm` command along with `add`, `update` or `remove` subcommands. Remember t
 Use `jsx` command along with `add`, `update` or `remove` subcommands. Remember to supply the
 `file path` parameter if your telemetry config is not at the default location.
 
-#### Parameters
+```
+Usage: ibmtelemetry-config jsx [options] [command]
 
-| Param     | Command                                                   | Usage               | Description                                                                                                                                                                                   | Required                                                                                        | Type             | Default           |
-| --------- | --------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------- | ----------------- |
-| file path | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file.                                                                                                        | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String           | `./telemetry.yml` |
-| files     | <ul><li>`add`</li><li>`update`</li></ul>                  | `-f`, `--files`     | Files to scan component props for (used to generate `allowedAttributeNames` and `allowedAttributeStringValues` arrays in JSX scope config). Can be a space-separated list of files or a glob. | Required                                                                                        | String[], String | -                 |
-| ignore    | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-i`, `--ignore`    | Files to ignore when scanning for JSX Scope attributes, in glob(s) form.                                                                                                                      | Optional                                                                                        | String[], String | -                 |
+Add, update or remove jsx scope
+
+Options:
+  -h, --help        display help for command
+
+Commands:
+  add [options]     Add jsx scope to current config file
+  update [options]  Regenerate the jsx scope
+  remove [options]  Remove jsx scope from current config file
+  help [command]    display help for command
+```
+
+#### Subcommands
+
+##### Add
+
+```
+Usage: ibmtelemetry-config jsx add [options]
+
+Add jsx scope to current config file
+
+Options:
+  -f, --files <files...>       List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options
+  -i, --ignore <files...>      Files to ignore when scanning for JSX Scope attributes, in glob(s) form.
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
+
+##### Update
+
+```
+Usage: ibmtelemetry-config jsx update [options]
+
+Regenerate the jsx scope
+
+Options:
+  -f, --files <files...>       List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options
+  -i, --ignore <files...>      Files to ignore when scanning for JSX Scope attributes, in glob(s) form.
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
+
+##### Remove
+
+```
+Usage: ibmtelemetry-config jsx remove [options]
+
+Remove jsx scope from current config file
+
+Options:
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
 
 #### Example Usage
 
@@ -125,11 +241,56 @@ Use `jsx` command along with `add`, `update` or `remove` subcommands. Remember t
 Use `js` command along with `add`, `update` or `remove` subcommands. Remember to supply the
 `file path` parameter if your telemetry config is not at the default location.
 
-#### Parameters
+```
+Add, update or remove js scope
 
-| Param     | Command                                                   | Usage               | Description                                                                            | Required                                                                                        | Type   | Default           |
-| --------- | --------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------ | ----------------- |
-| file path | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file. | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String | `./telemetry.yml` |
+Options:
+  -h, --help        display help for command
+
+Commands:
+  add [options]     Add js scope to current config file
+  update [options]  Regenerate the js scope
+  remove [options]  Remove js scope from current config file
+  help [command]    display help for command
+```
+
+#### Subcommands
+
+##### Add
+
+```
+Usage: ibmtelemetry-config js add [options]
+
+Add js scope to current config file
+
+Options:
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
+
+##### Update
+
+```
+Usage: ibmtelemetry-config js update [options]
+
+Regenerate the js scope
+
+Options:
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
+
+##### Remove
+
+```
+Usage: ibmtelemetry-config js remove [options]
+
+Remove js scope from current config file
+
+Options:
+  -p, --file-path <file-path>  Path to create config file at, defaults to `telemetry.yml` (default: "telemetry.yml")
+  -h, --help                   display help for command
+```
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Use this tool to automatically generate an
 [@ibm/telemetry-js](https://github.com/ibm-telemetry/telemetry-js) compatible `telemetry.yml` file
 with your project-specific configurations.
 
-> [!NOTE] For v1, please see
-> [v1 docs](https://github.com/ibm-telemetry/telemetry-js-config-generator/tree/v1.0.3?tab=readme-ov-file#ibm-telemetry-js-config-generator)
+> **Note**  
+> For v1, please see [v1 docs](https://github.com/ibm-telemetry/telemetry-js-config-generator/tree/v1.0.3?tab=readme-ov-file#ibm-telemetry-js-config-generator)
 
 ## Generating Config File
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ Use this tool to automatically generate an
 [@ibm/telemetry-js](https://github.com/ibm-telemetry/telemetry-js) compatible `telemetry.yml` file
 with your project-specific configurations.
 
-# Generating Config File
+> [!NOTE] For v1, please see
+> [v1 docs](https://github.com/ibm-telemetry/telemetry-js-config-generator/tree/v1.0.3?tab=readme-ov-file#ibm-telemetry-js-config-generator)
 
-From the root of the project that needs to be instrumented with IBM Telemetry, run the
-`telemetryconfig` command:
+## Generating Config File
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)`
+From the root of the project that needs to be instrumented with IBM Telemetry, run the `generate`
+command:
+
+`npx -y @ibm/telemetry-js-config-generator generate --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)`
 
 > Note that it is not necessary for your package to directly install this package as a dependency.
 > Instead, use `npx` to call the published collection script directly from the
@@ -21,65 +24,115 @@ From the root of the project that needs to be instrumented with IBM Telemetry, r
 Alternatively, if you decide to install the package as a dependency (to run it periodically within
 your CI environment, for example), you can call the bin like so:
 
-`ibmtelemetry-config --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)`
+`ibmtelemetry-config generate --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)`
 
 A `telemetry.yml` file will be generated inside the cwd path, unless a file path is specified (see
-[--p, --file-path](#p---file-path)). Verify that the generated output is correct before using the
-config file.
+parameters). Verify that the generated output is correct before using the config file.
 
-# Required Params
+### Parameters
 
-## --id
+| Param     | Usage               | Description                                                                                                                                                                                             | Required                                                                                                           | Type             | Default           |
+| --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------- | ----------------- |
+| id        | `--id`              | Unique identifier assigned on a per-project basis. See [Onboarding a package to IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js?tab=readme-ov-file#onboarding-a-package-to-ibm-telemetry). | Required                                                                                                           | String           | -                 |
+| endpoint  | `--endpoint`        | URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to.                                                                                            | Required                                                                                                           | String           | -                 |
+| files     | `-f`, `--files`     | Files to scan component props for (used to generate `allowedAttributeNames` and `allowedAttributeStringValues` arrays in JSX scope config). Can be a space-separated list of files or a glob.           | Required when including JSX scope in telemetry config file (done by default unless opt-out, see `--no-jsx` param). | String[], String | -                 |
+| file path | `-p`, `--file-path` | Path to create config file at.                                                                                                                                                                          | Optional                                                                                                           | String           | `./telemetry.yml` |
+| ignore    | `-i`, `--ignore`    | Files to ignore when scanning for JSX Scope attributes, in glob(s) form.                                                                                                                                | Optional                                                                                                           | String[], String | -                 |
+| no npm    | `--no-npm`          | Use this option to exclude `npm` scope config from generated telemetry config file.                                                                                                                     | Optional                                                                                                           | param only       | -                 |
+| no jsx    | `--no-jsx`          | Use this option to exclude `JSX` scope config from generated telemetry config file. Omit supplying the `-f, --files` and `-i, --ignore` arguments when opting out of JSX config.                        | Optional                                                                                                           | param only       | -                 |
+| no js     | `--no-js`           | Use this option to exclude `js` scope config from generated telemetry config file.                                                                                                                      | Optional                                                                                                           | param only       | -                 |
 
-Unique identifier assigned on a per-project basis. See
-[Onboarding a package to IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js?tab=readme-ov-file#onboarding-a-package-to-ibm-telemetry).
+### Example Usage
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)`
+`npx -y @ibm/telemetry-js-config-generator generate --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx) --file-path ./packages/sample/telemetry.yml -i **/DataTable/**/*.tsx **/Copy/** --no-npm --no-js`
 
-## --endpoint
+`ibmtelemetry-config generate --id sample-id --endpoint https://example.com/v1/metrics --no-jsx`
 
-URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry
-data to.
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)`
+## Updating existing config file
 
-## -f, --files
+To update an existing telemetry config file, run the `update` command. You can use this command to
+regenerate entirely a telemetry configuration or only in-part (see available parameters). Remember
+to supply the `file path` parameter if your telemetry config is not at the default location.
 
-Files to scan component props for (used to generate `allowedAttributeNames` and
-`allowedAttributeStringValues` arrays in JSX scope config). Can be a space-separated list of files
-or a glob.
+### Parameters
 
-> This parameter is only required when including JSX scope in telemetry config file (done by default
-> unless opt-out, see [--no-jsx](#no-jsx)).
+| Param     | Usage               | Description                                                                                                                                                                                                                                                                                                     | Required                                                                                        | Type             | Default           |
+| --------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------- | ----------------- |
+| id        | `--id`              | Unique identifier assigned on a per-project basis. See [Onboarding a package to IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js?tab=readme-ov-file#onboarding-a-package-to-ibm-telemetry). Supplying this optional parameter will overwrite the current `id` set in the existing telemetry config. | Optional                                                                                        | String           | -                 |
+| endpoint  | `--endpoint`        | URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to. Supplying this optional parameter will overwrite the current `endpoint` set in the existing telemetry config.                                                                                      | Optional                                                                                        | String           | -                 |
+| files     | `-f`, `--files`     | Files to scan component props for (used to generate `allowedAttributeNames` and `allowedAttributeStringValues` arrays in JSX scope config). Can be a space-separated list of files or a glob.                                                                                                                   | Optional. If this parameter is not specified, the `jsx` scope will **not** be regenerated.      | String[], String | -                 |
+| file path | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file.                                                                                                                                                                                                                          | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String           | `./telemetry.yml` |
+| ignore    | `-i`, `--ignore`    | Files to ignore when scanning for JSX Scope attributes, in glob(s) form.                                                                                                                                                                                                                                        | Optional                                                                                        | String[], String | -                 |
+| no npm    | `--no-npm`          | Use this option to bypass updating `npm` scope config. Note that an existing npm configuration will not be removed by using this option.                                                                                                                                                                        | Optional                                                                                        | param only       | -                 |
+| no jsx    | `--no-jsx`          | Use this option to bypass updating `jsx` scope config. Note that an existing jsx configuration will not be removed by using this option. Omit supplying the `-f, --files` and `-i, --ignore` arguments when opting out of JSX config.                                                                           | Optional                                                                                        | param only       | -                 |
+| no js     | `--no-js`           | Use this option to bypass updating `js` scope config. Note that an existing js configuration will not be removed by using this option.                                                                                                                                                                          | Optional                                                                                        | param only       | -                 |
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/specific-component-1.tsx ./src/components/specific-component-2.jsx`
+### Example Usage
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics -f ./src/components/**/*.(tsx|js|jsx)`
+`npx -y @ibm/telemetry-js-config-generator update --files ./src/components/**/*.(tsx|js|jsx)`
 
-# Optional Params
+`ibmtelemetry-config update --no-jsx`
 
-## -p, --file-path
+## Adding, removing and updating scopes
 
-Path to create config file at, defaults to `telemetry.yml`.
+You may add, update or remove scopes from an existing telemetry configuration file by using the
+scope specific commands:
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx) --file-path ./packages/sample/telemetry.yml`
+### npm
 
-# -i, --ignore
+Use `npm` command along with `add`, `update` or `remove` subcommands. Remember to supply the
+`file path` parameter if your telemetry config is not at the default location.
 
-Files to ignore when scanning for JSX Scope attributes, in glob(s) form.
+#### Parameters
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics -f ./src/components/**/*.(tsx|js|jsx) --ignore **/DataTable/*.tsx`
+| Param     | Command                                                   | Usage               | Description                                                                            | Required                                                                                        | Type   | Default           |
+| --------- | --------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------ | ----------------- |
+| file path | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file. | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String | `./telemetry.yml` |
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics -f ./src/components/**/*.(tsx|js|jsx) -i **/DataTable/**/*.tsx **/Copy/**`
+#### Example Usage
 
-## --no-npm
+`npx -y @ibm/telemetry-js-config-generator npm add`
 
-Use this option to exclude npm scope config from generated telemetry config file.
+`ibmtelemetry-config npm update`
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics --files ./src/components/**/*.(tsx|js|jsx) --no-npm`
+`npx -y @ibm/telemetry-js-config-generator npm remove`
 
-## --no-jsx
+### jsx
 
-Use this option to exclude JSX scope config from generated telemetry config file. Omit supplying the
-`-f, --files` argument when option out of JSX config.
+Use `jsx` command along with `add`, `update` or `remove` subcommands. Remember to supply the
+`file path` parameter if your telemetry config is not at the default location.
 
-`npx -y @ibm/telemetry-js-config-generator --id sample-id --endpoint https://example.com/v1/metrics --no-jsx`
+#### Parameters
+
+| Param     | Command                                                   | Usage               | Description                                                                                                                                                                                   | Required                                                                                        | Type             | Default           |
+| --------- | --------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------- | ----------------- |
+| file path | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file.                                                                                                        | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String           | `./telemetry.yml` |
+| files     | <ul><li>`add`</li><li>`update`</li></ul>                  | `-f`, `--files`     | Files to scan component props for (used to generate `allowedAttributeNames` and `allowedAttributeStringValues` arrays in JSX scope config). Can be a space-separated list of files or a glob. | Required                                                                                        | String[], String | -                 |
+| ignore    | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-i`, `--ignore`    | Files to ignore when scanning for JSX Scope attributes, in glob(s) form.                                                                                                                      | Optional                                                                                        | String[], String | -                 |
+
+#### Example Usage
+
+`npx -y @ibm/telemetry-js-config-generator jsx add -f ./src/components/**/*.(tsx|js|jsx) --ignore **/DataTable/**/*.tsx **/Copy/**`
+
+`ibmtelemetry-config jsx update --files ./src/components/**/*.(tsx|js|jsx)`
+
+`npx -y @ibm/telemetry-js-config-generator jsx remove`
+
+### js
+
+Use `js` command along with `add`, `update` or `remove` subcommands. Remember to supply the
+`file path` parameter if your telemetry config is not at the default location.
+
+#### Parameters
+
+| Param     | Command                                                   | Usage               | Description                                                                            | Required                                                                                        | Type   | Default           |
+| --------- | --------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------ | ----------------- |
+| file path | <ul><li>`add`</li><li>`update`</li><li>`remove`</li></ul> | `-p`, `--file-path` | Path to read and write config file at. Should be the path to the existing config file. | Optional. Program will try to read the current config file from `'./telemetry.yml'` if omitted. | String | `./telemetry.yml` |
+
+#### Example Usage
+
+`npx -y @ibm/telemetry-js-config-generator js add`
+
+`ibmtelemetry-config js update`
+
+`npx -y @ibm/telemetry-js-config-generator js remove`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "yaml": "^2.4.5"
       },
       "bin": {
-        "ibmtelemetry-config": "dist/generate-config-file.js"
+        "ibmtelemetry-config": "dist/index.js"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ibmtelemetry-config": "dist/index.js"
   },
   "files": [
-    "dist/index.js"
+    "dist/*"
   ],
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "type": "module",
   "main": "index.js",
   "bin": {
-    "ibmtelemetry-config": "dist/generate-config-file.js"
+    "ibmtelemetry-config": "dist/index.js"
   },
   "files": [
-    "dist/generate-config-file.js"
+    "dist/index.js"
   ],
   "scripts": {
     "build": "tsc",

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/*
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Command, InvalidArgumentError } from 'commander'
+import yaml from 'yaml'
+
+import { getJsScopeConfig } from '../common/get-js-scope-config.js'
+import { getJsxScopeConfig } from '../common/get-jsx-scope-config.js'
+import { getNpmScopeConfig } from '../common/get-npm-scope-config.js'
+import { writeConfigFile } from '../common/write-config-file.js'
+import { type CommandLineOptions } from '../interfaces.js'
+
+function buildGenerateCommand() {
+  return new Command('generate')
+    .description('Generate IBM telemetry config file.')
+    .requiredOption(
+      '--id <project-id>',
+      'Project Id, should be obtained from the IBM Telemetry team'
+    )
+    .requiredOption(
+      '--endpoint <endpoint>',
+      'URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to.'
+    )
+    .option(
+      '-f, --files <files...>',
+      'List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options'
+    )
+    .option(
+      '-i, --ignore <files...>',
+      'Files to ignore when scanning for JSX Scope attributes, in glob(s) form.'
+    )
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .option('--no-npm', 'Disables config generation for npm scope')
+    .option('--no-jsx', 'Disables config generation for JSX scope')
+    .option('--no-js', 'Disables config generation for JS scope')
+    .action(generateConfigFile)
+}
+
+/**
+ * Generates telemetry.yml config file based on input parameters.
+ *
+ * @param opts - The command line options provided when the command was executed.
+ */
+async function generateConfigFile(opts: CommandLineOptions) {
+  if (opts.jsx && !opts.files) {
+    throw new InvalidArgumentError('--files argument must be specified for JSX scope generation')
+  }
+
+  const doc = new yaml.Document({
+    version: 1,
+    projectId: opts.id,
+    endpoint: opts.endpoint
+  })
+
+  doc.commentBefore =
+    ' yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json'
+
+  // can't pull in type from ConfigSchema because using
+  // allowedAttributeNames/allowedAttributeStringValues
+  // as yaml.Node array to be able to preserve comments
+  const collect: Record<string, unknown> = {}
+
+  if (opts.jsx && opts.files) {
+    const jsxContents = await getJsxScopeConfig(opts.files, opts.ignore, doc)
+    if (jsxContents !== null) {
+      collect['jsx'] = jsxContents
+    }
+  }
+
+  if (opts.npm) {
+    collect['npm'] = getNpmScopeConfig()
+  }
+
+  if (opts.js) {
+    collect['js'] = getJsScopeConfig()
+  }
+
+  doc.set('collect', collect)
+
+  writeConfigFile(opts.filePath, doc.toString())
+}
+
+export { buildGenerateCommand }

--- a/src/commands/js.ts
+++ b/src/commands/js.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Command } from 'commander'
+
+import { readConfigFile } from '../common/read-config-file.js'
+import { removeScopeFromConfig } from '../common/remove-scope-from-config.js'
+import { updateJsConfig } from '../common/update-js-config.js'
+import { writeConfigFile } from '../common/write-config-file.js'
+import { type CommandLineOptions } from '../interfaces.js'
+
+function buildJsCommand() {
+  const jsCommand = new Command('js').description('add, update or remove js scope')
+
+  jsCommand
+    .command('add')
+    .description('add js scope to current config file')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateJsConfigInFile(opts, 'add'))
+
+  jsCommand
+    .command('update')
+    .description('regenerate the js scope')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateJsConfigInFile(opts, 'update'))
+
+  jsCommand
+    .command('remove')
+    .description('remove js scope from current config file')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => removeScopeFromConfig(opts.filePath, 'js'))
+
+  return jsCommand
+}
+
+/**
+ * Adds or updates the JS scope configuration within an existing config file.
+ *
+ * @param opts - The command line options provided when the command was executed.
+ * @param action - Indicates whether the JS scope needs to be added or updated.
+ */
+async function updateJsConfigInFile(
+  opts: Partial<CommandLineOptions> & Pick<CommandLineOptions, 'filePath'>,
+  action: 'add' | 'update'
+) {
+  const configFile = readConfigFile(opts.filePath)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+  const collectNode = configFile.get('collect') as any
+
+  if (collectNode === undefined || collectNode === null) {
+    console.error('Existing config file is misconfigured. Please generate a new one.')
+    return
+  }
+
+  if (action === 'update' && collectNode.get('js') === undefined) {
+    console.error('JS scope not configured. Cannot update')
+    return
+  }
+
+  updateJsConfig(collectNode)
+
+  configFile.set('collect', collectNode)
+
+  writeConfigFile(opts.filePath, configFile.toString())
+}
+
+export { buildJsCommand }

--- a/src/commands/js.ts
+++ b/src/commands/js.ts
@@ -15,11 +15,11 @@ import { writeConfigFile } from '../common/write-config-file.js'
 import { type CommandLineOptions } from '../interfaces.js'
 
 function buildJsCommand() {
-  const jsCommand = new Command('js').description('add, update or remove js scope')
+  const jsCommand = new Command('js').description('Add, update or remove js scope')
 
   jsCommand
     .command('add')
-    .description('add js scope to current config file')
+    .description('Add js scope to current config file')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',
@@ -29,7 +29,7 @@ function buildJsCommand() {
 
   jsCommand
     .command('update')
-    .description('regenerate the js scope')
+    .description('Regenerate the js scope')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',
@@ -39,7 +39,7 @@ function buildJsCommand() {
 
   jsCommand
     .command('remove')
-    .description('remove js scope from current config file')
+    .description('Remove js scope from current config file')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',

--- a/src/commands/jsx.ts
+++ b/src/commands/jsx.ts
@@ -15,11 +15,11 @@ import { writeConfigFile } from '../common/write-config-file.js'
 import { type CommandLineOptions } from '../interfaces.js'
 
 function buildJsxCommand() {
-  const jsxCommand = new Command('jsx').description('add, update or remove jsx scope')
+  const jsxCommand = new Command('jsx').description('Add, update or remove jsx scope')
 
   jsxCommand
     .command('add')
-    .description('add jsx scope to current config file')
+    .description('Add jsx scope to current config file')
     .requiredOption(
       '-f, --files <files...>',
       'List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options'
@@ -37,7 +37,7 @@ function buildJsxCommand() {
 
   jsxCommand
     .command('update')
-    .description('regenerate the jsx scope')
+    .description('Regenerate the jsx scope')
     .requiredOption(
       '-f, --files <files...>',
       'List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options'
@@ -55,7 +55,7 @@ function buildJsxCommand() {
 
   jsxCommand
     .command('remove')
-    .description('remove jsx scope from current config file')
+    .description('Remove jsx scope from current config file')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',

--- a/src/commands/jsx.ts
+++ b/src/commands/jsx.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Command } from 'commander'
+
+import { readConfigFile } from '../common/read-config-file.js'
+import { removeScopeFromConfig } from '../common/remove-scope-from-config.js'
+import { updateJsxConfig } from '../common/update-jsx-config.js'
+import { writeConfigFile } from '../common/write-config-file.js'
+import { type CommandLineOptions } from '../interfaces.js'
+
+function buildJsxCommand() {
+  const jsxCommand = new Command('jsx').description('add, update or remove jsx scope')
+
+  jsxCommand
+    .command('add')
+    .description('add jsx scope to current config file')
+    .requiredOption(
+      '-f, --files <files...>',
+      'List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options'
+    )
+    .option(
+      '-i, --ignore <files...>',
+      'Files to ignore when scanning for JSX Scope attributes, in glob(s) form.'
+    )
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateJsxConfigInFile(opts, 'add'))
+
+  jsxCommand
+    .command('update')
+    .description('regenerate the jsx scope')
+    .requiredOption(
+      '-f, --files <files...>',
+      'List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options'
+    )
+    .option(
+      '-i, --ignore <files...>',
+      'Files to ignore when scanning for JSX Scope attributes, in glob(s) form.'
+    )
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateJsxConfigInFile(opts, 'update'))
+
+  jsxCommand
+    .command('remove')
+    .description('remove jsx scope from current config file')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => removeScopeFromConfig(opts.filePath, 'jsx'))
+
+  return jsxCommand
+}
+
+/**
+ * Adds or updates the JSX scope configuration within an existing config file.
+ *
+ * @param opts - The command line options provided when the command was executed.
+ * @param action - Indicates whether the JSX scope needs to be added or updated.
+ */
+async function updateJsxConfigInFile(
+  opts: Partial<CommandLineOptions> & Pick<CommandLineOptions, 'filePath'>,
+  action: 'add' | 'update'
+) {
+  const configFile = readConfigFile(opts.filePath)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+  const collectNode = configFile.get('collect') as any
+
+  if (collectNode === undefined || collectNode === null) {
+    console.error('Existing config file is misconfigured. Please generate a new one.')
+    return
+  }
+
+  if (action === 'update' && collectNode.get('jsx') === undefined) {
+    console.error('JSX scope not configured. Cannot update')
+    return
+  }
+
+  updateJsxConfig(collectNode, opts.files, opts.ignore, configFile)
+
+  configFile.set('collect', collectNode)
+
+  writeConfigFile(opts.filePath, configFile.toString())
+}
+
+export { buildJsxCommand }

--- a/src/commands/npm.ts
+++ b/src/commands/npm.ts
@@ -15,11 +15,11 @@ import { writeConfigFile } from '../common/write-config-file.js'
 import { type CommandLineOptions } from '../interfaces.js'
 
 function buildNpmCommand() {
-  const npmCommand = new Command('npm').description('add, update or remove npm scope')
+  const npmCommand = new Command('npm').description('Add, update or remove npm scope')
 
   npmCommand
     .command('add')
-    .description('add npm scope to current config file')
+    .description('Add npm scope to current config file')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',
@@ -29,7 +29,7 @@ function buildNpmCommand() {
 
   npmCommand
     .command('update')
-    .description('regenerate the npm scope')
+    .description('Regenerate the npm scope')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',
@@ -39,7 +39,7 @@ function buildNpmCommand() {
 
   npmCommand
     .command('remove')
-    .description('remove npm scope from current config file')
+    .description('Remove npm scope from current config file')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',

--- a/src/commands/npm.ts
+++ b/src/commands/npm.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Command } from 'commander'
+
+import { readConfigFile } from '../common/read-config-file.js'
+import { removeScopeFromConfig } from '../common/remove-scope-from-config.js'
+import { updateNpmConfig } from '../common/update-npm-config.js'
+import { writeConfigFile } from '../common/write-config-file.js'
+import { type CommandLineOptions } from '../interfaces.js'
+
+function buildNpmCommand() {
+  const npmCommand = new Command('npm').description('add, update or remove npm scope')
+
+  npmCommand
+    .command('add')
+    .description('add npm scope to current config file')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateNpmConfigInFile(opts, 'add'))
+
+  npmCommand
+    .command('update')
+    .description('regenerate the npm scope')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateNpmConfigInFile(opts, 'update'))
+
+  npmCommand
+    .command('remove')
+    .description('remove npm scope from current config file')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => removeScopeFromConfig(opts.filePath, 'npm'))
+
+  return npmCommand
+}
+
+/**
+ * Adds or updates the npm scope configuration within an existing config file.
+ *
+ * @param opts - The command line options provided when the command was executed.
+ * @param action - Indicates whether the npm scope needs to be added or updated.
+ */
+async function updateNpmConfigInFile(
+  opts: Partial<CommandLineOptions> & Pick<CommandLineOptions, 'filePath'>,
+  action: 'add' | 'update'
+) {
+  const configFile = readConfigFile(opts.filePath)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+  const collectNode = configFile.get('collect') as any
+
+  if (collectNode === undefined || collectNode === null) {
+    console.error('Existing config file is misconfigured. Please generate a new one.')
+    return
+  }
+
+  if (action === 'update' && collectNode.get('npm') === undefined) {
+    console.error('npm scope not configured. Cannot update')
+    return
+  }
+
+  updateNpmConfig(collectNode)
+
+  configFile.set('collect', collectNode)
+
+  writeConfigFile(opts.filePath, configFile.toString())
+}
+
+export { buildNpmCommand }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Command } from 'commander'
+
+import { readConfigFile } from '../common/read-config-file.js'
+import { updateJsConfig } from '../common/update-js-config.js'
+import { updateJsxConfig } from '../common/update-jsx-config.js'
+import { updateNpmConfig } from '../common/update-npm-config.js'
+import { writeConfigFile } from '../common/write-config-file.js'
+import { type CommandLineOptions } from '../interfaces.js'
+
+function buildUpdateCommand() {
+  return new Command('update')
+    .description('modify in whole or part an existing telemetry config file')
+    .option('--id <project-id>', 'Project Id, should be obtained from the IBM Telemetry team')
+    .option(
+      '--endpoint <endpoint>',
+      'URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to.'
+    )
+    .option(
+      '-f, --files <files...>',
+      'List of files to scan for JSX Scope attributes, can be an array of path(s) or glob(s). Required to generate JSX scope options'
+    )
+    .option(
+      '-i, --ignore <files...>',
+      'Files to ignore when scanning for JSX Scope attributes, in glob(s) form.'
+    )
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .option('--no-npm', 'Disables config generation for npm scope')
+    .option('--no-jsx', 'Disables config generation for JSX scope')
+    .option('--no-js', 'Disables config generation for JS scope')
+    .action((opts) => updateConfigFile(opts))
+}
+
+/**
+ * Regenerates in part of whole a telemetry configuration within an existing config file.
+ *
+ * @param opts - The command line options provided when the command was executed.
+ */
+async function updateConfigFile(
+  opts: Partial<CommandLineOptions> & Pick<CommandLineOptions, 'filePath'>
+) {
+  const configFile = readConfigFile(opts.filePath)
+
+  // get returns unknown and can't figure out what the type cast is supposed to be
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+  const collectNode = configFile.get('collect') as any
+
+  if (collectNode === undefined || collectNode === null) {
+    console.error('Existing config file is misconfigured. Please generate a new one.')
+    return
+  }
+
+  if (opts.npm && collectNode.get('npm') !== undefined) {
+    updateNpmConfig(collectNode)
+  }
+
+  if (opts.js && collectNode.get('js') !== undefined) {
+    updateJsConfig(collectNode)
+  }
+
+  if (opts.jsx && collectNode.get('jsx') !== undefined) {
+    if (!opts.files) {
+      console.warn('Warning: skipping JSX scope regeneration, --files argument not set')
+    } else {
+      await updateJsxConfig(collectNode, opts.files, opts.ignore, configFile)
+    }
+  }
+
+  if (opts.id !== null && opts.id !== undefined) {
+    configFile.set('projectId', opts.id)
+  }
+
+  if (opts.endpoint !== null && opts.endpoint !== undefined) {
+    configFile.set('endpoint', opts.endpoint)
+  }
+
+  configFile.set('collect', collectNode)
+
+  writeConfigFile(opts.filePath, configFile.toString())
+}
+
+export { buildUpdateCommand }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -17,7 +17,7 @@ import { type CommandLineOptions } from '../interfaces.js'
 
 function buildUpdateCommand() {
   return new Command('update')
-    .description('modify in whole or part an existing telemetry config file')
+    .description('Modify in whole or part an existing telemetry config file')
     .option('--id <project-id>', 'Project Id, should be obtained from the IBM Telemetry team')
     .option(
       '--endpoint <endpoint>',

--- a/src/common/get-js-scope-config.ts
+++ b/src/common/get-js-scope-config.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Generates a default JS scope config.
+ *
+ * @returns Correct Js (default) scope configuration.
+ */
+export function getJsScopeConfig() {
+  return {
+    functions: {},
+    tokens: null
+  }
+}

--- a/src/common/get-npm-scope-config.ts
+++ b/src/common/get-npm-scope-config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Generates a default npm scope config.
+ *
+ * @returns Correct npm (default) scope configuration.
+ */
+export function getNpmScopeConfig() {
+  return { dependencies: null }
+}

--- a/src/common/read-config-file.ts
+++ b/src/common/read-config-file.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import fs from 'node:fs'
+
+import yaml from 'yaml'
+
+/**
+ * Retrieves a telemetry config object from an existing config file.
+ *
+ * @param filePath - Path to read telemetry config file from.
+ * @returns Yaml.doc parsed document obtained from existing config file.
+ */
+export function readConfigFile(filePath: string) {
+  const file = fs.readFileSync(filePath, 'utf8')
+  return yaml.parseDocument(file)
+}

--- a/src/common/remove-scope-from-config.ts
+++ b/src/common/remove-scope-from-config.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { TelemetryScope } from '../interfaces.js'
+import { readConfigFile } from './read-config-file.js'
+import { writeConfigFile } from './write-config-file.js'
+
+/**
+ * Removes a determined scope configuration from an existing telemetry config file..
+ *
+ * @param filePath - Path to existing telemetry config file.
+ * @param scope - Scope to remove.
+ */
+export async function removeScopeFromConfig(filePath: string, scope: TelemetryScope) {
+  const configFile = readConfigFile(filePath)
+
+  // get returns unknown and can't figure out what the type cast is supposed to be
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `get` returns unknown
+  const collectNode = configFile.get('collect') as any
+
+  if (collectNode === undefined || collectNode === null) {
+    console.error('Existing config file is misconfigured. Please generate a new one.')
+    return
+  }
+
+  collectNode.delete(scope)
+
+  if (collectNode.items?.length === 0) {
+    console.warn('Cannot delete scope. At least 1 scope is required')
+  } else {
+    writeConfigFile(filePath, configFile.toString())
+  }
+}

--- a/src/common/update-js-config.ts
+++ b/src/common/update-js-config.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// get returns unknown and can't figure out what the type cast is supposed to be
+
+import { getJsScopeConfig } from './get-js-scope-config.js'
+
+/**
+ * Updates the JS scope configuration within an existing `collect` node.
+ *
+ * @param collectNode - Collect node extracted from a yaml.Document containing
+ * an existing telemetry configuration.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure of yaml type
+export function updateJsConfig(collectNode: any) {
+  collectNode.set('js', getJsScopeConfig())
+}

--- a/src/common/update-jsx-config.ts
+++ b/src/common/update-jsx-config.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { InvalidArgumentError } from 'commander'
+import yaml from 'yaml'
+
+import { getJsxScopeConfig } from './get-jsx-scope-config.js'
+
+/**
+ * Updates the JSX scope configuration within an existing `collect` node.
+ *
+ * @param collectNode - Collect node extracted from a yaml.Document containing
+ * an existing telemetry configuration.
+ * @param files - List of files to scan for JSX Scope attributes,
+ * can be an array of path(s) or glob(s).
+ * @param ignore - Files to ignore when scanning for JSX Scope attributes, in glob(s) form.
+ * @param configFile - Yaml.document object containing current configuration.
+ */
+export async function updateJsxConfig(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+  collectNode: any,
+  files: string[] | undefined,
+  ignore: string[] | undefined,
+  configFile: yaml.Document
+) {
+  if (!files) {
+    throw new InvalidArgumentError('--files argument must be specified for JSX scope generation')
+  }
+  collectNode.set('jsx', await getJsxScopeConfig(files, ignore, configFile))
+}

--- a/src/common/update-npm-config.ts
+++ b/src/common/update-npm-config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { getNpmScopeConfig } from './get-npm-scope-config.js'
+
+/**
+ * Updates the npm scope configuration within an existing `collect` node.
+ *
+ * @param collectNode - Collect node extracted from a yaml.Document containing
+ * an existing telemetry configuration.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+export function updateNpmConfig(collectNode: any) {
+  collectNode.set('npm', getNpmScopeConfig())
+}

--- a/src/common/write-config-file.ts
+++ b/src/common/write-config-file.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import fs from 'node:fs'
+
+/**
+ * Write a provided telemetry configuration object to a specified file.
+ *
+ * @param filePath - Path to write config file to.
+ * @param contents - Yaml.document object containing telemetry configuration to write to file.
+ */
+export function writeConfigFile(filePath: string, contents: string) {
+  try {
+    fs.writeFileSync(filePath, contents)
+    // file written successfully
+  } catch (err) {
+    console.error('Error writing to file: ', err)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { Command } from 'commander'
+
+import { buildGenerateCommand } from './commands/generate.js'
+import { buildJsCommand } from './commands/js.js'
+import { buildJsxCommand } from './commands/jsx.js'
+import { buildNpmCommand } from './commands/npm.js'
+import { buildUpdateCommand } from './commands/update.js'
+
+async function main() {
+  const program = new Command()
+    .configureHelp({ helpWidth: 100 })
+    .addCommand(buildGenerateCommand())
+    .addCommand(buildUpdateCommand())
+    .addCommand(buildNpmCommand())
+    .addCommand(buildJsCommand())
+    .addCommand(buildJsxCommand())
+
+  try {
+    await program.parseAsync()
+  } catch (err) {
+    // As a failsafe, this catches any uncaught exception, prints it to stderr, and silently exits
+    console.error(err)
+  }
+}
+
+await main()

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,7 @@ export interface CommandLineOptions {
   filePath: string
   npm: boolean
   jsx: boolean
+  js: boolean
   ignore?: string[]
 }
 
@@ -55,3 +56,5 @@ export interface CompData {
 }
 
 export type CompPropTypes = Record<string, Record<string, string[]>>
+
+export type TelemetryScope = 'jsx' | 'js' | 'npm'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,7 +50,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": false,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
Closes #2 

Introduces specialized per-scope commands: `npm`, `js`, `jsx`. Also introduces `update` command. Moves current logic to new `generate command`

#### Changelog

**New**

- Introduces JS scope configuration generation
- `index.js` entry file
- `JS` scope command to add, update or remove JS scope configuration to existing telemetry config files
- `JSX` scope command to add, update or remove JSX scope configuration to existing telemetry config files
- `npm` scope command to add, update or remove npm scope configuration to existing telemetry config files
- `update` command to modify in part or whole an existing telemetry config files
- Utility functions to support new commands functionality

**Changed**

- Moved primary file generation logic to dedicated `generate` command here src/commands/generate.ts

#### Testing / reviewing

Tested manually