### PR TITLE
fix: await jsx update command

### DIFF
--- a/src/commands/jsx.ts
+++ b/src/commands/jsx.ts
@@ -91,7 +91,7 @@ async function updateJsxConfigInFile(
     return
   }
 
-  updateJsxConfig(collectNode, opts.files, opts.ignore, configFile)
+  await updateJsxConfig(collectNode, opts.files, opts.ignore, configFile)
 
   configFile.set('collect', collectNode)
 


### PR DESCRIPTION
Fixes bug where `jsx add` and `jsx update` commands where not working due to the command not being awaited.
 
#### Changelog

**Changed**

- add `await` to `updateJsxConfig` in `jsx` command file.


#### Testing / reviewing

Tested locally