### PR TITLE
chore: update copyright notices for telemetry-js-config-generator

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.copyright.js
+++ b/.copyright.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. <%= YEAR %>, 2024
+ * Copyright IBM Corp. <%= YEAR %>, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -135,7 +135,7 @@ module.exports = {
     ],
     'n/shebang': 'off',
     'notice/notice': [
-      'warn',
+      'error',
       {
         templateFile: path.join(__dirname, '.copyright.js')
       }

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/scripts/format-package-json.js
+++ b/scripts/format-package-json.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2024
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/commands/js.ts
+++ b/src/commands/js.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/commands/jsx.ts
+++ b/src/commands/jsx.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/commands/npm.ts
+++ b/src/commands/npm.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/get-js-scope-config.ts
+++ b/src/common/get-js-scope-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/get-jsx-scope-config.ts
+++ b/src/common/get-jsx-scope-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/get-npm-scope-config.ts
+++ b/src/common/get-npm-scope-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/read-config-file.ts
+++ b/src/common/read-config-file.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/remove-scope-from-config.ts
+++ b/src/common/remove-scope-from-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/update-js-config.ts
+++ b/src/common/update-js-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/update-jsx-config.ts
+++ b/src/common/update-jsx-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/update-npm-config.ts
+++ b/src/common/update-npm-config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/common/write-config-file.ts
+++ b/src/common/write-config-file.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Closes ibm-telemetry/telemetry-internal#285

#### Changelog

**Changed**

- eslint copyright notice rule changed from warning to error
- updated notice template to current year 2025
- updated current year to 2025 in all existing source file notices

#### Testing / reviewing

- all source file notices should be properly updated
- newly created files should have proper notice added when `npm run lint:fix` runs