### PR TITLE
feat: add web component scope to config generator

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -33,11 +33,11 @@ function buildGenerateCommand() {
     )
     .option(
       '-f, --files <files...>',
-      'List of files to scan for component attributes. Can be an array of path(s) or glob(s). Required for JSX and Web Component scopes.'
+      'Files to scan for component attributes. Can be an array of path(s) or glob(s). Required for JSX and Web Component scopes.'
     )
     .option(
       '-i, --ignore <files...>',
-      'Files to ignore when scanning for component attributes, in glob(s) form.'
+      'Files to ignore when scanning for JSX Scope attributes, in glob(s) form.'
     )
     .option(
       '-p, --file-path <file-path>',
@@ -96,7 +96,7 @@ async function generateConfigFile(opts: CommandLineOptions) {
   }
 
   if (wcScope && opts.files) {
-    const wcContents = await getWcScopeConfig(opts.files, opts.ignore, doc)
+    const wcContents = await getWcScopeConfig(opts.files, doc)
     if (wcContents !== null) {
       collect['wc'] = wcContents
     }

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -28,7 +28,7 @@ function buildGenerateCommand() {
       'URL of an OpenTelemetry-compatible metrics collector API endpoint. Used to post collected telemetry data to.'
     )
     .requiredOption(
-      '--scopes <scopes..>',
+      '--scopes <scopes...>',
       'List of scopes to include in config generation. Valid scopes are "js", "jsx", "npm", and "wc". "jsx" and "wc" cannot be included together.'
     )
     .option(

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -12,6 +12,7 @@ import yaml from 'yaml'
 import { getJsScopeConfig } from '../common/get-js-scope-config.js'
 import { getJsxScopeConfig } from '../common/get-jsx-scope-config.js'
 import { getNpmScopeConfig } from '../common/get-npm-scope-config.js'
+import { getWcScopeConfig } from '../common/get-wc-scope-config.js'
 import { writeConfigFile } from '../common/write-config-file.js'
 import { type CommandLineOptions } from '../interfaces.js'
 
@@ -42,6 +43,7 @@ function buildGenerateCommand() {
     .option('--no-npm', 'Disables config generation for npm scope')
     .option('--no-jsx', 'Disables config generation for JSX scope')
     .option('--no-js', 'Disables config generation for JS scope')
+    .option('--no-wc', 'Disables config generation for Web Component scope')
     .action(generateConfigFile)
 }
 
@@ -82,6 +84,10 @@ async function generateConfigFile(opts: CommandLineOptions) {
 
   if (opts.js) {
     collect['js'] = getJsScopeConfig()
+  }
+
+  if (opts.wc) {
+    collect['wc'] = getWcScopeConfig()
   }
 
   doc.set('collect', collect)

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -12,6 +12,7 @@ import { readConfigFile } from '../common/read-config-file.js'
 import { updateJsConfig } from '../common/update-js-config.js'
 import { updateJsxConfig } from '../common/update-jsx-config.js'
 import { updateNpmConfig } from '../common/update-npm-config.js'
+import { updateWcConfig } from '../common/update-wc-config.js'
 import { writeConfigFile } from '../common/write-config-file.js'
 import { type CommandLineOptions } from '../interfaces.js'
 
@@ -39,6 +40,7 @@ function buildUpdateCommand() {
     .option('--no-npm', 'Disables config generation for npm scope')
     .option('--no-jsx', 'Disables config generation for JSX scope')
     .option('--no-js', 'Disables config generation for JS scope')
+    .option('--no-wc', 'Disables config generation for Web Component scope')
     .action((opts) => updateConfigFile(opts))
 }
 
@@ -75,6 +77,10 @@ async function updateConfigFile(
     } else {
       await updateJsxConfig(collectNode, opts.files, opts.ignore, configFile)
     }
+  }
+
+  if (opts.wc && collectNode.get('wc') !== undefined) {
+    updateWcConfig(collectNode)
   }
 
   if (opts.id !== null && opts.id !== undefined) {

--- a/src/commands/wc.ts
+++ b/src/commands/wc.ts
@@ -15,14 +15,14 @@ import { writeConfigFile } from '../common/write-config-file.js'
 import { type CommandLineOptions } from '../interfaces.js'
 
 function buildWcCommand() {
-  const wcCommand = new Command('wc').description('Add, update or remove Web Component scope')
+  const wcCommand = new Command('wc').description('Add, update or remove web component scope')
 
   wcCommand
     .command('add')
-    .description('Add Web Component scope to current config file')
+    .description('Add web component scope to current config file')
     .requiredOption(
       '-f, --files <files...>',
-      `List of files to scan for Web Component scope attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope 
+      `List of files to scan for web component scope attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope 
       options`
     )
     .option(
@@ -38,7 +38,7 @@ function buildWcCommand() {
 
   wcCommand
     .command('update')
-    .description('Regenerate the Web Component scope')
+    .description('Regenerate the web component scope')
     .requiredOption(
       '-f, --files <files...>',
       `List of files to scan for Web Component scope attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope 
@@ -57,7 +57,7 @@ function buildWcCommand() {
 
   wcCommand
     .command('remove')
-    .description('Remove Web Component scope from current config file')
+    .description('Remove web component scope from current config file')
     .option(
       '-p, --file-path <file-path>',
       'Path to create config file at, defaults to `telemetry.yml`',

--- a/src/commands/wc.ts
+++ b/src/commands/wc.ts
@@ -22,12 +22,7 @@ function buildWcCommand() {
     .description('Add web component scope to current config file')
     .requiredOption(
       '-f, --files <files...>',
-      `List of files to scan for web component scope attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope 
-      options`
-    )
-    .option(
-      '-i, --ignore <files...>',
-      'Files to ignore when scanning for Web Component scope attributes, in glob(s) form.'
+      'Files to scan for Web Component attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope options'
     )
     .option(
       '-p, --file-path <file-path>',
@@ -41,12 +36,7 @@ function buildWcCommand() {
     .description('Regenerate the web component scope')
     .requiredOption(
       '-f, --files <files...>',
-      `List of files to scan for Web Component scope attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope 
-      options`
-    )
-    .option(
-      '-i, --ignore <files...>',
-      'Files to ignore when scanning for Web Component scope attributes, in glob(s) form.'
+      'Files to scan for Web Component attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope options'
     )
     .option(
       '-p, --file-path <file-path>',
@@ -93,7 +83,7 @@ async function updateWcConfigInFile(
     return
   }
 
-  await updateWcConfig(collectNode)
+  await updateWcConfig(collectNode, opts.files, configFile)
 
   configFile.set('collect', collectNode)
 

--- a/src/commands/wc.ts
+++ b/src/commands/wc.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/*
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Command } from 'commander'
+
+import { readConfigFile } from '../common/read-config-file.js'
+import { removeScopeFromConfig } from '../common/remove-scope-from-config.js'
+import { updateWcConfig } from '../common/update-wc-config.js'
+import { writeConfigFile } from '../common/write-config-file.js'
+import { type CommandLineOptions } from '../interfaces.js'
+
+function buildWcCommand() {
+  const wcCommand = new Command('wc').description('Add, update or remove Web Component scope')
+
+  wcCommand
+    .command('add')
+    .description('Add Web Component scope to current config file')
+    .requiredOption(
+      '-f, --files <files...>',
+      `List of files to scan for Web Component scope attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope 
+      options`
+    )
+    .option(
+      '-i, --ignore <files...>',
+      'Files to ignore when scanning for Web Component scope attributes, in glob(s) form.'
+    )
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateWcConfigInFile(opts, 'add'))
+
+  wcCommand
+    .command('update')
+    .description('Regenerate the Web Component scope')
+    .requiredOption(
+      '-f, --files <files...>',
+      `List of files to scan for Web Component scope attributes, can be an array of path(s) or glob(s). Required to generate Web Component scope 
+      options`
+    )
+    .option(
+      '-i, --ignore <files...>',
+      'Files to ignore when scanning for Web Component scope attributes, in glob(s) form.'
+    )
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => updateWcConfigInFile(opts, 'update'))
+
+  wcCommand
+    .command('remove')
+    .description('Remove Web Component scope from current config file')
+    .option(
+      '-p, --file-path <file-path>',
+      'Path to create config file at, defaults to `telemetry.yml`',
+      'telemetry.yml'
+    )
+    .action((opts) => removeScopeFromConfig(opts.filePath, 'wc'))
+
+  return wcCommand
+}
+
+/**
+ * Adds or updates the Web Component scope configuration within an existing config file.
+ *
+ * @param opts - The command line options provided when the command was executed.
+ * @param action - Indicates whether the Web Component scope needs to be added or updated.
+ */
+async function updateWcConfigInFile(
+  opts: Partial<CommandLineOptions> & Pick<CommandLineOptions, 'filePath'>,
+  action: 'add' | 'update'
+) {
+  const configFile = readConfigFile(opts.filePath)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+  const collectNode = configFile.get('collect') as any
+
+  if (collectNode === undefined || collectNode === null) {
+    console.error('Existing config file is misconfigured. Please generate a new one.')
+    return
+  }
+
+  if (action === 'update' && collectNode.get('wc') === undefined) {
+    console.error('Web Component scope not configured. Cannot update')
+    return
+  }
+
+  await updateWcConfig(collectNode)
+
+  configFile.set('collect', collectNode)
+
+  writeConfigFile(opts.filePath, configFile.toString())
+}
+
+export { buildWcCommand }

--- a/src/common/get-wc-scope-config.ts
+++ b/src/common/get-wc-scope-config.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Generates a default Web Component scope config.
+ *
+ * @returns Correct Web Component (default) scope configuration.
+ */
+export function getWcScopeConfig() {
+  return {
+    functions: {},
+    tokens: null
+  }
+}

--- a/src/common/get-wc-scope-config.ts
+++ b/src/common/get-wc-scope-config.ts
@@ -10,7 +10,7 @@
  *
  * @returns Correct Web Component (default) scope configuration.
  */
-export function getWcScopeConfig() {
+export async function getWcScopeConfig() {
   return {
     functions: {},
     tokens: null

--- a/src/common/get-wc-scope-config.ts
+++ b/src/common/get-wc-scope-config.ts
@@ -4,15 +4,264 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import childProcess from 'node:child_process'
+import fs from 'node:fs'
+
+import { tmpNameSync } from 'tmp-promise'
+import yaml, { type Node } from 'yaml'
+
+import {
+  AttributeValue,
+  AttributeData,
+  WebCompData,
+  WcaOutput,
+  WebCompAttributes
+} from '../interfaces.js'
 
 /**
- * Generates a default Web Component scope config.
- *
- * @returns Correct Web Component (default) scope configuration.
+ * Creates a project-specific Web Component scope configuration to be placed inside telemetry config file.
+ * @param files - List of files to scan for Web Component Scope attributes,
+ * can be an array of path(s) or glob(s).
+ * @param doc - Yaml.document object containing current configuration.
+ * @returns Web Component scope configuration containing element attribute and values
+ *  as determined by the supplied files.
  */
-export async function getWcScopeConfig() {
-  return {
-    functions: {},
-    tokens: null
+export async function getWcScopeConfig(files: string[], doc: yaml.Document) {
+  const outputFilePath = await generateComponentData(files)
+
+  if (!fs.existsSync(outputFilePath)) {
+    console.error('No web-component-analyzer file was generated for these settings')
+    return null
+  } else {
+    const data = fs.readFileSync(outputFilePath, 'utf-8')
+
+    const rawData: WcaOutput = JSON.parse(data)
+
+    const webCompAttributes = parseCompData(rawData)
+
+    const [names, values] = await getAttributeNameAndValues(webCompAttributes, doc)
+
+    fs.unlinkSync(outputFilePath)
+
+    return {
+      elements: {
+        allowedAttributeNames: names,
+        allowedAttributeStringValues: values
+      }
+    }
+  }
+}
+
+/**
+ * This is the main entrypoint for telemetry collection.
+ *
+ * @param files - List of files to generate component data for.
+ * @returns A promise that resolves to the path of output file containing generated data.
+ */
+async function generateComponentData(files: string[]): Promise<string> {
+  let errorData = ''
+  const date = new Date().toISOString()
+  const outputFilePath = tmpNameSync({
+    template: `ibmtelemetry-config-${date.replace(/[:.-]/g, '')}-XXXXXX.json`
+  })
+  return await new Promise<string>((resolve, reject) => {
+    const proc = childProcess.spawn(
+      // eslint-disable-next-line max-len -- long command
+      `npx web-component-analyzer analyze ${files.join(
+        ' '
+      )} --format vscode --outFile ${outputFilePath}`,
+      { shell: true }
+    )
+
+    proc.stderr?.on('data', (data) => {
+      errorData += data.toString()
+    })
+
+    proc.on('error', (err) => {
+      console.error('Error: ', err)
+      reject(err)
+    })
+
+    proc.on('close', (exitCode) => {
+      if (exitCode !== 0) {
+        console.error('Error: ', errorData)
+        reject(new Error(errorData))
+      } else {
+        resolve(outputFilePath)
+      }
+    })
+  })
+}
+
+/**
+ * Extracts attribute values array from a supplied AttributeData object.
+ *
+ * @param attributeData - Raw attribute data.
+ * @returns Attribute values as a string array.
+ */
+function getAttributeValues(attributeData: AttributeData): string[] {
+  const values: string[] = []
+  if (attributeData.values) {
+    attributeData.values.forEach((val: AttributeValue) => values.push(val.name))
+  } else if (attributeData.valueSet === 'v') {
+    values.push('true', 'false')
+  }
+  return values
+}
+
+/**
+ * Populates the supplied `partialCompAttributes` object with attribute data
+ * parsed from the raw `compData` object.
+ *
+ * @param compData - Raw component data.
+ * @param partialCompAttributes - State tracker object of previously computed attributes
+ * for supplied component.
+ * @returns Populated partialCompAttributes object.
+ */
+function addCompAttributes(
+  compData: WebCompData,
+  partialCompAttributes: Record<string, string[]>
+): Record<string, string[]> {
+  if (compData.attributes) {
+    compData.attributes.forEach((attr) => {
+      const attributeValues = [
+        ...getAttributeValues(attr),
+        ...(partialCompAttributes[attr.name] ?? [])
+      ]
+      // remove duplicates and sort attribute values
+      partialCompAttributes[attr.name] = attributeValues
+        .filter((value, index) => attributeValues.indexOf(value) === index)
+        .sort((a, b) => a.localeCompare(b))
+    })
+  }
+  // sort comp attributes by names
+  const orderedAttributeKeys = Object.keys(partialCompAttributes).sort((a, b) => a.localeCompare(b))
+  return orderedAttributeKeys.reduce<Record<string, string[]>>((obj, key) => {
+    const data = partialCompAttributes[key]
+    if (data) {
+      obj[key] = data
+    }
+    return obj
+  }, {})
+}
+
+/**
+ * Given a WebCompAttributes object, groups common attributes into a general category.
+ *
+ * @param webCompAttributes - Previously processed component attributes data,
+ * ordered by component name and attribute key.
+ * @returns WebCompAttributes object containing general category.
+ */
+function groupGeneralAttributes(webCompAttributes: WebCompAttributes) {
+  const general: Record<string, string[]> = {}
+  // add General category
+  const allCompAttributes: WebCompAttributes = {
+    General: general,
+    ...webCompAttributes
+  }
+
+  // Compute General Attributes
+  Object.entries(webCompAttributes).forEach(([key, value]) => {
+    Object.keys(value).forEach((attr) => {
+      const hasDuplicate: boolean =
+        general[attr] !== undefined ||
+        Object.entries(allCompAttributes).some(
+          ([duplKey, duplValue]) =>
+            duplKey !== key && Object.keys(duplValue).some((duplAttr) => duplAttr === attr)
+        )
+      if (hasDuplicate) {
+        const generalAttribute = general[attr]
+        if (generalAttribute) {
+          generalAttribute.push(...(value[attr] ?? []))
+        } else {
+          general[attr] = [...(value[attr] ?? [])]
+        }
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- need to do this
+        delete value[attr]
+        // always true, but TypeScript...
+        if (generalAttribute) {
+          // remove duplicates
+          general[attr] = generalAttribute.filter(
+            (val, index) => generalAttribute.indexOf(val) === index
+          )
+        }
+      }
+    })
+  })
+
+  return allCompAttributes
+}
+
+/**
+ * Parses the raw components data obtained from a `generateConfigFile` into a
+ * comprehensible WebCompAttributes object.
+ *
+ * @param rawData - Raw components data.
+ * @returns Parsed WebCompAttributes object.
+ */
+function parseCompData(rawData: WcaOutput): WebCompAttributes {
+  const webCompAttributes: WebCompAttributes = {}
+  rawData.tags.forEach((component: WebCompData) => {
+    webCompAttributes[component.name] = addCompAttributes(
+      component,
+      webCompAttributes[component.name] ?? {}
+    )
+  })
+  // sort by component names
+  const orderedCompAttributeKeys = Object.keys(webCompAttributes).sort((a, b) => a.localeCompare(b))
+
+  const orderedCompAttributes = orderedCompAttributeKeys.reduce<WebCompAttributes>((obj, key) => {
+    const data = webCompAttributes[key]
+    if (data) {
+      obj[key] = data
+    }
+    return obj
+  }, {})
+
+  return groupGeneralAttributes(orderedCompAttributes)
+}
+
+/**
+ * Constructs yaml node array of names and values given a WebCompAttributes object.
+ *
+ * @param webCompAttributes - Component attributes data.
+ * @param doc - Yaml Document to attach nodes to.
+ * @returns Promise containing two arrays, [names, values].
+ */
+async function getAttributeNameAndValues(
+  webCompAttributes: WebCompAttributes,
+  doc: yaml.Document
+): Promise<[Array<Node | string>, Array<Node | string>]> {
+  try {
+    const names: Array<Node | string> = []
+    const values: Array<Node | string> = []
+
+    Object.entries(webCompAttributes).forEach(([comp, attributes]) => {
+      const orderedCompAttributes = Object.entries(attributes).sort((a, b) =>
+        a[0].localeCompare(b[0])
+      )
+      orderedCompAttributes.forEach(([attrKey, attrValues], index) => {
+        attrValues.sort((a, b) => a.localeCompare(b))
+        const attrNode = doc.createNode(attrKey)
+        names.push(attrNode)
+        if (index === 0) {
+          attrNode.commentBefore = ` ${comp}`
+        }
+        attrValues.forEach((val: unknown, index) => {
+          if (typeof val === 'string') {
+            const attrValNode = doc.createNode(val)
+            if (index === 0) {
+              attrValNode.commentBefore = ` ${comp} - ${attrKey}`
+            }
+            values.push(attrValNode)
+          }
+        })
+      })
+    })
+
+    return [names, values]
+  } catch (e) {
+    console.error('Error parsing output json data: ', e)
+    return [[], []]
   }
 }

--- a/src/common/get-wc-scope-config.ts
+++ b/src/common/get-wc-scope-config.ts
@@ -103,8 +103,6 @@ function getAttributeValues(attributeData: AttributeData): string[] {
   const values: string[] = []
   if (attributeData.values) {
     attributeData.values.forEach((val: AttributeValue) => values.push(val.name))
-  } else if (attributeData.valueSet === 'v') {
-    values.push('true', 'false')
   }
   return values
 }
@@ -259,6 +257,10 @@ async function getAttributeNameAndValues(
       })
     })
 
+    // add boolean attribute values
+    const booleanTrueNode = doc.createNode('true')
+    booleanTrueNode.commentBefore = ' General - boolean attributes'
+    values.unshift(booleanTrueNode, 'false')
     return [names, values]
   } catch (e) {
     console.error('Error parsing output json data: ', e)

--- a/src/common/update-wc-config.ts
+++ b/src/common/update-wc-config.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// get returns unknown and can't figure out what the type cast is supposed to be
+
+import { getWcScopeConfig } from './get-wc-scope-config.js'
+
+/**
+ * Updates the Web Component scope configuration within an existing `collect` node.
+ *
+ * @param collectNode - Collect node extracted from a yaml.Document containing
+ * an existing telemetry configuration.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure of yaml type
+export function updateWcConfig(collectNode: any) {
+  collectNode.set('wc', getWcScopeConfig())
+}

--- a/src/common/update-wc-config.ts
+++ b/src/common/update-wc-config.ts
@@ -4,7 +4,9 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// get returns unknown and can't figure out what the type cast is supposed to be
+
+import { InvalidArgumentError } from 'commander'
+import yaml from 'yaml'
 
 import { getWcScopeConfig } from './get-wc-scope-config.js'
 
@@ -13,8 +15,20 @@ import { getWcScopeConfig } from './get-wc-scope-config.js'
  *
  * @param collectNode - Collect node extracted from a yaml.Document containing
  * an existing telemetry configuration.
+ * @param files - Files to scan for Web Component Scope attributes,
+ * can be an array of path(s) or glob(s).
+ * @param configFile - Yaml.document object containing current configuration.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure of yaml type
-export function updateWcConfig(collectNode: any) {
-  collectNode.set('wc', getWcScopeConfig())
+export async function updateWcConfig(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unsure what the type cast is
+  collectNode: any,
+  files: string[] | undefined,
+  configFile: yaml.Document
+) {
+  if (!files) {
+    throw new InvalidArgumentError(
+      '--files argument must be specified for Web Component scope generation'
+    )
+  }
+  collectNode.set('wc', await getWcScopeConfig(files, configFile))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { buildJsCommand } from './commands/js.js'
 import { buildJsxCommand } from './commands/jsx.js'
 import { buildNpmCommand } from './commands/npm.js'
 import { buildUpdateCommand } from './commands/update.js'
+import { buildWcCommand } from './commands/wc.js'
 
 async function main() {
   const program = new Command()
@@ -21,6 +22,7 @@ async function main() {
     .addCommand(buildNpmCommand())
     .addCommand(buildJsCommand())
     .addCommand(buildJsxCommand())
+    .addCommand(buildWcCommand())
 
   try {
     await program.parseAsync()

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,14 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 export interface CommandLineOptions {
-  files?: string[]
   id: string
   endpoint: string
   filePath: string
-  npm: boolean
-  jsx: boolean
-  js: boolean
-  wc: boolean
+  scopes: string[]
+  files?: string[]
   ignore?: string[]
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,6 +13,10 @@ export interface CommandLineOptions {
   ignore?: string[]
 }
 
+export type TelemetryScope = 'jsx' | 'js' | 'npm' | 'wc'
+
+// JSX Scope
+
 export interface EnumValue {
   value: string
   computed: boolean
@@ -55,4 +59,25 @@ export interface CompData {
 
 export type CompPropTypes = Record<string, Record<string, string[]>>
 
-export type TelemetryScope = 'jsx' | 'js' | 'npm' | 'wc'
+// Web Component Scope
+
+export interface AttributeValue {
+  name: string
+}
+
+export interface AttributeData {
+  name: string
+  valueSet?: string
+  values?: AttributeValue[]
+}
+
+export interface WebCompData {
+  name: string
+  attributes?: AttributeData[]
+}
+
+export interface WcaOutput {
+  tags: WebCompData[]
+}
+
+export type WebCompAttributes = Record<string, Record<string, string[]>>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,7 @@ export interface CommandLineOptions {
   npm: boolean
   jsx: boolean
   js: boolean
+  wc: boolean
   ignore?: string[]
 }
 
@@ -57,4 +58,4 @@ export interface CompData {
 
 export type CompPropTypes = Record<string, Record<string, string[]>>
 
-export type TelemetryScope = 'jsx' | 'js' | 'npm'
+export type TelemetryScope = 'jsx' | 'js' | 'npm' | 'wc'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,9 +8,12 @@ export interface CommandLineOptions {
   id: string
   endpoint: string
   filePath: string
-  scopes: string[]
   files?: string[]
   ignore?: string[]
+  npm: boolean
+  jsx: boolean
+  js: boolean
+  wc: boolean
 }
 
 export type TelemetryScope = 'jsx' | 'js' | 'npm' | 'wc'


### PR DESCRIPTION
Closes ibm-telemetry/telemetry-internal#290

Generate telemetry.yml config file for web component packages

#### Changelog

**New**

- adds `--wc` option to `generate` and `update` commands to include a web components scope in the config file. Requires JSX scope to be disabled with `--no-jsx`.
- `web-component-analyzer` package used to extract attribute data from web components

#### Testing / reviewing

- tested `generate` and `update` commands in carbon/web-components
- tested that `generate` and `update` commands still work as expected in carbon/react
